### PR TITLE
fixing scale of USL + slightly adjusting position for sparse mapping

### DIFF
--- a/astrobee_iss/urdf/model.urdf
+++ b/astrobee_iss/urdf/model.urdf
@@ -107,13 +107,13 @@
     </collision>
     <!-- Node 2 -->
     <visual name="iss_node_2_visual">
-      <origin xyz="10.9344206  0.0107442 4.8558958" rpy="0 0 0" />
+      <origin xyz="10.9744206  -0.0112558 4.8358958" rpy="0 0 0" />
       <geometry>
         <mesh filename="package://astrobee_iss/meshes/node_2.dae"/>
       </geometry>
     </visual>
     <collision name="iss_node_2_collision">
-      <origin xyz="10.9344206  0.0107442 4.8558958" rpy="0 0 0" />
+      <origin xyz="10.9744206  -0.0112558 4.8358958" rpy="0 0 0" />
       <geometry>
         <mesh filename="package://astrobee_iss/meshes/node_2.dae"/>
       </geometry>
@@ -147,15 +147,15 @@
     </collision>
     <!-- US Lab -->
     <visual name="iss_us_lab_visual">
-      <origin xyz="6.3085472  0.0064770 4.8508920" rpy="3.1415 0 0" />
+      <origin xyz="6.3085472  0.0064770 4.8348920" rpy="3.1415 0 0" />
       <geometry>
-        <mesh filename="package://astrobee_iss/meshes/us_lab.dae"/>
+        <mesh filename="package://astrobee_iss/meshes/us_lab.dae" scale="1.0858 1.0858 1.0858"/>
       </geometry>
     </visual>
     <collision name="iss_us_lab_collision">
-      <origin xyz="6.3085472  0.0064770 4.8508920" rpy="3.1415 0 0" />
+      <origin xyz="6.4125472  0.0064770 4.8348920" rpy="3.1415 0 0" />
       <geometry>
-        <mesh filename="package://astrobee_iss/meshes/us_lab.dae"/>
+        <mesh filename="package://astrobee_iss/meshes/us_lab.dae" scale="1.0858 1.0858 1.0858"/>
       </geometry>
       <gazebo>
         <surface>

--- a/astrobee_iss/urdf/model.urdf
+++ b/astrobee_iss/urdf/model.urdf
@@ -106,6 +106,8 @@
       </gazebo>
     </collision>
     <!-- Node 2 -->
+    <!-- The positions defer slightly from the ISS documentation, adjusted
+    to match the relative node position for bundle adjusted sparse mapping -->
     <visual name="iss_node_2_visual">
       <origin xyz="10.9744206  -0.0112558 4.8358958" rpy="0 0 0" />
       <geometry>
@@ -146,6 +148,10 @@
       </gazebo>
     </collision>
     <!-- US Lab -->
+    <!-- The scale was changed to match what the iGoal model finds and validated
+    both through measuring the hatches (ISS hatches are the same size) and through
+    sparse mapping validation. The positions defer slightly from the ISS documentation,
+    adjusted to match the relative node position for bundle adjusted sparse mapping -->
     <visual name="iss_us_lab_visual">
       <origin xyz="6.3085472  0.0064770 4.8348920" rpy="3.1415 0 0" />
       <geometry>


### PR DESCRIPTION
 * Fixed USL scale + changed positions. -- This might not be the best way of doing this update but it's the fastest/does not require uploading new binaries. Alternatively we could have changed the models themselves and kept the urdf 1:1 with the ISS documentation regarding module pose.