### PR TITLE
Add texcoord to freeflyer meshes

### DIFF
--- a/astrobee_freeflyer/meshes/arm_distal_link.dae
+++ b/astrobee_freeflyer/meshes/arm_distal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/arm_proximal_link.dae
+++ b/astrobee_freeflyer/meshes/arm_proximal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/base_link.dae
+++ b/astrobee_freeflyer/meshes/base_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/gripper_left_distal_link.dae
+++ b/astrobee_freeflyer/meshes/gripper_left_distal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.125 0.125 0.125 1</color>

--- a/astrobee_freeflyer/meshes/gripper_left_proximal_link.dae
+++ b/astrobee_freeflyer/meshes/gripper_left_proximal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/gripper_right_distal_link.dae
+++ b/astrobee_freeflyer/meshes/gripper_right_distal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/gripper_right_proximal_link.dae
+++ b/astrobee_freeflyer/meshes/gripper_right_proximal_link.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="black_png-sampler"/>
+              <texture texture="black_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/pmc_skin_.dae
+++ b/astrobee_freeflyer/meshes/pmc_skin_.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="skin_debug_right_png-sampler"/>
+              <texture texture="skin_debug_right_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/pmc_skin_bumble.dae
+++ b/astrobee_freeflyer/meshes/pmc_skin_bumble.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="skin_debug_right_png-sampler"/>
+              <texture texture="skin_debug_right_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/pmc_skin_honey.dae
+++ b/astrobee_freeflyer/meshes/pmc_skin_honey.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="skin_debug_right_png-sampler"/>
+              <texture texture="skin_debug_right_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>

--- a/astrobee_freeflyer/meshes/pmc_skin_queen.dae
+++ b/astrobee_freeflyer/meshes/pmc_skin_queen.dae
@@ -37,7 +37,7 @@
               <color sid="ambient">0 0 0 1</color>
             </ambient>
             <diffuse>
-              <texture texture="skin_debug_right_png-sampler"/>
+              <texture texture="skin_debug_right_png-sampler" texcoord="UVSET0"/>
             </diffuse>
             <specular>
               <color sid="specular">0.25 0.25 0.25 1</color>


### PR DESCRIPTION
Same modifications as in #9 

I did notice that in `granite.dae`, that one used a different texcoord: `<texture texture="granite_png-sampler" texcoord="UVMap"/>` -- I stuck with the UVSET0 parameter, but I'm not sure if this makes a difference